### PR TITLE
fix issue 22

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 name := "akka-cluster-custom-downing"
 
-organization := "com.github.TanUkkii007"
+organization := "akka-cluster-custom-dowing"
 
 homepage := Some(url("https://github.com/TanUkkii007/akka-cluster-custom-downing"))
 

--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,8 @@ scalacOptions ++= Seq(
   "-feature",
   "-deprecation",
   "-unchecked",
-  "-encoding", "UTF-8",
+  "-encoding",
+  "UTF-8",
   "-language:implicitConversions",
   "-language:postfixOps",
   "-language:higherKinds"
@@ -23,7 +24,7 @@ licenses += ("Apache-2.0", url("http://www.apache.org/licenses/LICENSE-2.0"))
 val akkaVersion = "2.5.23"
 
 libraryDependencies ++= Seq(
-  "com.typesafe.akka" %% "akka-actor" % akkaVersion,
+  "com.typesafe.akka" %% "akka-actor"   % akkaVersion,
   "com.typesafe.akka" %% "akka-cluster" % akkaVersion,
 //  "com.typesafe.akka" %% "akka-cluster" % akkaVersion  % "test" classifier "tests",
   "com.typesafe.akka" %% "akka-multi-node-testkit" % akkaVersion % Test,
@@ -52,10 +53,20 @@ executeTests in Test := Def.task {
   )
 }.value
 
+assemblyMergeStrategy in (MultiJvm, assembly) := {
+  case "application.conf" => MergeStrategy.concat
+  case "META-INF/aop.xml" => MergeStrategy.concat
+  case x =>
+    val old = (assemblyMergeStrategy in (MultiJvm, assembly)).value
+    old(x)
+}
+
+Test / fork := true
+
 configs(MultiJvm)
 
 BintrayPlugin.autoImport.bintrayPackage := "akka-cluster-custom-downing"
 
-enablePlugins(BintrayPlugin, ReleasePlugin)
+enablePlugins(MultiJvmPlugin, BintrayPlugin, ReleasePlugin)
 
 releaseCrossBuild := true

--- a/src/main/scala/tanukki/akka/cluster/autodown/CustomAutoDownBase.scala
+++ b/src/main/scala/tanukki/akka/cluster/autodown/CustomAutoDownBase.scala
@@ -5,7 +5,6 @@
   * The original source code can be found here.
   * https://github.com/akka/akka/blob/master/akka-cluster/src/main/scala/akka/cluster/AutoDown.scala
   */
-
 package tanukki.akka.cluster.autodown
 
 import akka.actor.{ Actor, Address, Cancellable, Scheduler }
@@ -18,7 +17,8 @@ object CustomDowning {
   case class UnreachableTimeout(member: Member)
 }
 
-abstract class CustomAutoDownBase(autoDownUnreachableAfter: FiniteDuration) extends Actor {
+abstract class CustomAutoDownBase(autoDownUnreachableAfter: FiniteDuration)
+    extends Actor {
 
   import CustomDowning._
 
@@ -79,7 +79,9 @@ abstract class CustomAutoDownBase(autoDownUnreachableAfter: FiniteDuration) exte
     if (autoDownUnreachableAfter == Duration.Zero) {
       downOrAddPending(m)
     } else {
-      val task = scheduler.scheduleOnce(autoDownUnreachableAfter, self, UnreachableTimeout(m))
+      val task = scheduler.scheduleOnce(autoDownUnreachableAfter,
+                                        self,
+                                        UnreachableTimeout(m))
       scheduledUnreachable += (m -> task)
     }
   }
@@ -91,15 +93,19 @@ abstract class CustomAutoDownBase(autoDownUnreachableAfter: FiniteDuration) exte
     unstableUnreachable -= member
   }
 
-  def scheduledUnreachableMembers: Map[Member, Cancellable] = scheduledUnreachable
+  def scheduledUnreachableMembers: Map[Member, Cancellable] =
+    scheduledUnreachable
 
   def pendingUnreachableMembers: Set[Member] = pendingUnreachable
 
   def pendingAsUnreachable(member: Member): Unit = pendingUnreachable += member
 
   def downPendingUnreachableMembers(): Unit = {
-    pendingUnreachable.foreach(member => down(member.address))
-    pendingUnreachable = Set.empty
+    val (head, tail) = pendingUnreachable.splitAt(1)
+    head.foreach { member =>
+      down(member.address)
+    }
+    pendingUnreachable = tail
   }
 
   def unstableUnreachableMembers: Set[Member] = unstableUnreachable

--- a/src/main/scala/tanukki/akka/cluster/autodown/OldestAutoDownBase.scala
+++ b/src/main/scala/tanukki/akka/cluster/autodown/OldestAutoDownBase.scala
@@ -16,8 +16,7 @@ abstract class OldestAutoDownBase(
       downPendingUnreachableMembers()
   }
 
-  override def onMemberRemoved(member: Member,
-                               previousStatus: MemberStatus): Unit = {
+  override def onMemberRemoved(member: Member, previousStatus: MemberStatus): Unit = {
     if (isOldestOf(oldestMemberRole))
       downPendingUnreachableMembers()
   }
@@ -25,8 +24,7 @@ abstract class OldestAutoDownBase(
   override def downOrAddPending(member: Member): Unit = {
     if (isOldestOf(oldestMemberRole)) {
       down(member.address)
-      replaceMember(member.copy(Down))
-   } else {
+    } else {
       pendingAsUnreachable(member)
     }
   }

--- a/src/main/scala/tanukki/akka/cluster/autodown/OldestAutoDownBase.scala
+++ b/src/main/scala/tanukki/akka/cluster/autodown/OldestAutoDownBase.scala
@@ -11,7 +11,13 @@ abstract class OldestAutoDownBase(
     autoDownUnreachableAfter: FiniteDuration
 ) extends OldestAwareCustomAutoDownBase(autoDownUnreachableAfter) {
 
-  override def onMemberRemoved(member: Member, previousStatus: MemberStatus): Unit = {
+  override def onMemberDowned(member: Member): Unit = {
+    if (isOldestOf(oldestMemberRole, member))
+      downPendingUnreachableMembers()
+  }
+
+  override def onMemberRemoved(member: Member,
+                               previousStatus: MemberStatus): Unit = {
     if (isOldestOf(oldestMemberRole))
       downPendingUnreachableMembers()
   }
@@ -20,7 +26,7 @@ abstract class OldestAutoDownBase(
     if (isOldestOf(oldestMemberRole)) {
       down(member.address)
       replaceMember(member.copy(Down))
-    } else {
+   } else {
       pendingAsUnreachable(member)
     }
   }

--- a/src/multi-jvm/scala/tanukki/akka/cluster/autodown/issue22/MultiNodeOldestAutoDownSpec.scala
+++ b/src/multi-jvm/scala/tanukki/akka/cluster/autodown/issue22/MultiNodeOldestAutoDownSpec.scala
@@ -1,0 +1,84 @@
+package tanukki.akka.cluster.autodown.issue22
+
+import akka.cluster.{Member, MultiNodeClusterSpec}
+import akka.remote.testconductor.RoleName
+import akka.remote.testkit.{MultiNodeSpec, STMultiNodeSpec}
+import akka.testkit.LongRunningTest
+
+import scala.collection.immutable
+import scala.collection.immutable.SortedSet
+import scala.concurrent.duration._
+
+class OldestAutoDowningNodeThatIsUnreachableWithAccrualFailureDetectorMultiJvmNode1
+    extends MultiNodeOldestAutoDownSpec(
+      MultiNodeOldestAutoDownSpecConfig(failureDetectorPuppet = false)
+    )
+class OldestAutoDowningNodeThatIsUnreachableWithAccrualFailureDetectorMultiJvmNode2
+    extends MultiNodeOldestAutoDownSpec(
+      MultiNodeOldestAutoDownSpecConfig(failureDetectorPuppet = false)
+    )
+class OldestAutoDowningNodeThatIsUnreachableWithAccrualFailureDetectorMultiJvmNode3
+    extends MultiNodeOldestAutoDownSpec(
+      MultiNodeOldestAutoDownSpecConfig(failureDetectorPuppet = false)
+    )
+
+abstract class MultiNodeOldestAutoDownSpec(
+    multiNodeConfig: MultiNodeOldestAutoDownSpecConfig
+) extends MultiNodeSpec(multiNodeConfig)
+    with STMultiNodeSpec
+    with MultiNodeClusterSpec {
+  import multiNodeConfig._
+
+  muteMarkingAsUnreachable()
+
+  "The oldest member in a 3 node cluster" must {
+    "issue-22" taggedAs LongRunningTest in {
+      awaitClusterUp(nodeA, nodeB, nodeC)
+      val secondAddress = node(nodeB).address
+      val thirdAddress = node(nodeC).address
+
+      enterBarrier("before-exit-two-node")
+      runOn(nodeA) {
+        // kill 'fifth' node
+        testConductor.exit(nodeB, 0).await
+        testConductor.exit(nodeC, 0).await
+        enterBarrier("down-two-node")
+
+        // mark the node as unreachable in the failure detector
+        markNodeAsUnavailable(secondAddress)
+        markNodeAsUnavailable(thirdAddress)
+
+        awaitMembersUp(
+          numberOfMembers = 1,
+          canNotBePartOfMemberRing = Set(secondAddress, thirdAddress),
+          30.seconds
+        )
+      }
+
+      runOn(nodeB, nodeC) {
+        enterBarrier("down-two-node")
+      }
+
+      runOn(nodeA) {
+        enterBarrier("down-two-node")
+
+        awaitMembersUp(
+          numberOfMembers = 1,
+          canNotBePartOfMemberRing = Set(secondAddress, thirdAddress),
+          30.seconds
+        )
+      }
+      enterBarrier("await-completion-1")
+
+    }
+  }
+
+  def membersByAge: SortedSet[Member] =
+    immutable.SortedSet(clusterView.members.toSeq: _*)(Member.ageOrdering)
+
+  def roleByMember(member: Member): RoleName =
+    roles.find(r => address(r) == member.address).get
+
+  def isFirst(roleName: RoleName): Boolean = address(roleName) == address(nodeA)
+
+}

--- a/src/multi-jvm/scala/tanukki/akka/cluster/autodown/issue22/MultiNodeOldestAutoDownSpec.scala
+++ b/src/multi-jvm/scala/tanukki/akka/cluster/autodown/issue22/MultiNodeOldestAutoDownSpec.scala
@@ -39,7 +39,7 @@ abstract class MultiNodeOldestAutoDownSpec(
 
       enterBarrier("before-exit-two-node")
       runOn(nodeA) {
-        // kill 'fifth' node
+        // kill 'second' and 'third'
         testConductor.exit(nodeB, 0).await
         testConductor.exit(nodeC, 0).await
         enterBarrier("down-two-node")

--- a/src/multi-jvm/scala/tanukki/akka/cluster/autodown/issue22/MultiNodeOldestAutoDownSpecConfig.scala
+++ b/src/multi-jvm/scala/tanukki/akka/cluster/autodown/issue22/MultiNodeOldestAutoDownSpecConfig.scala
@@ -1,0 +1,45 @@
+package tanukki.akka.cluster.autodown.issue22
+
+import akka.cluster.MultiNodeClusterSpec
+import akka.remote.testkit.MultiNodeConfig
+import com.typesafe.config.ConfigFactory
+
+final case class MultiNodeOldestAutoDownSpecConfig(
+  failureDetectorPuppet: Boolean
+) extends MultiNodeConfig {
+  val nodeA = role("master")
+  val nodeB = role("nodeB")
+  val nodeC = role("nodeC")
+
+  commonConfig(
+    ConfigFactory
+      .parseString("""
+          |akka.cluster.downing-provider-class = "tanukki.akka.cluster.autodown.OldestAutoDowning"
+          |custom-downing {
+          |  stable-after = 1s
+          |
+          |  oldest-auto-downing {
+          |    oldest-member-role = "master"
+          |    down-if-alone = false
+          |  }
+          |}
+          |akka.cluster.metrics.enabled=off
+          |akka.actor.warn-about-java-serializer-usage = off
+          |akka.remote.log-remote-lifecycle-events = off
+    """.stripMargin)
+      .withFallback(MultiNodeClusterSpec.clusterConfig(failureDetectorPuppet))
+  )
+
+  nodeConfig(nodeA)(ConfigFactory.parseString("""
+                                                |akka.cluster {
+                                                |  roles = ["master"]
+                                                |}
+    """.stripMargin))
+
+  nodeConfig(nodeB, nodeC)(ConfigFactory.parseString("""
+                                                              |akka.cluster {
+                                                              |  roles = [role]
+                                                              |}
+    """.stripMargin))
+
+}

--- a/src/test/scala/tanukki/akka/cluster/autodown/OldestAutoDownRolesSpec.scala
+++ b/src/test/scala/tanukki/akka/cluster/autodown/OldestAutoDownRolesSpec.scala
@@ -7,17 +7,14 @@
   */
 
 package tanukki.akka.cluster.autodown
-import akka.pattern.ask
+
 import akka.actor._
 import akka.cluster.ClusterEvent._
 import akka.cluster.MemberStatus._
-import akka.cluster.{ Member, MemberStatus, TestMember }
-import akka.util.Timeout
+import akka.cluster.{ Member, TestMember }
 
-import scala.concurrent.duration.{ Duration, FiniteDuration }
-import scala.concurrent.duration._
 import scala.collection.immutable
-import scala.util.{ Failure, Success }
+import scala.concurrent.duration.{ Duration, FiniteDuration, _ }
 
 case class DownCalledBySecondaryOldest(address: Address)
 


### PR DESCRIPTION
fix https://github.com/TanUkkii007/akka-cluster-custom-downing/issues/22

- test log

```
sbt:akka-cluster-custom-downing> multi-jvm:testOnly tanukki.akka.cluster.autodown.issue22.OldestAutoDowningNodeThatIsUnreachableWithAccrualFailureDetector
[info] Compiling 14 Scala sources to /Users/j5ik2o/Sources/org/akka-cluster-custom-downing/target/scala-2.13/multi-jvm-classes ...
[info] Done compiling.
[info] * tanukki.akka.cluster.autodown.issue22.OldestAutoDowningNodeThatIsUnreachableWithAccrualFailureDetector
[JVM-3] [INFO] [10/29/2019 19:27:56.416] [ScalaTest-main] [akka.remote.Remoting] Starting remoting
[JVM-2] [INFO] [10/29/2019 19:27:56.483] [ScalaTest-main] [akka.remote.Remoting] Starting remoting
[JVM-1] [INFO] [10/29/2019 19:27:56.501] [ScalaTest-main] [akka.remote.Remoting] Starting remoting
[JVM-3] [INFO] [10/29/2019 19:27:56.687] [ScalaTest-main] [akka.remote.Remoting] Remoting started; listening on addresses :[akka.tcp://MultiNodeOldestAutoDownSpec@localhost:54033]
[JVM-3] [INFO] [10/29/2019 19:27:56.708] [ScalaTest-main] [akka.cluster.Cluster(akka://MultiNodeOldestAutoDownSpec)] Cluster Node [akka.tcp://MultiNodeOldestAutoDownSpec@localhost:54033] - Starting up, Akka version [2.5.23] ...
[JVM-2] [INFO] [10/29/2019 19:27:56.722] [ScalaTest-main] [akka.remote.Remoting] Remoting started; listening on addresses :[akka.tcp://MultiNodeOldestAutoDownSpec@localhost:54034]
[JVM-2] [INFO] [10/29/2019 19:27:56.748] [ScalaTest-main] [akka.cluster.Cluster(akka://MultiNodeOldestAutoDownSpec)] Cluster Node [akka.tcp://MultiNodeOldestAutoDownSpec@localhost:54034] - Starting up, Akka version [2.5.23] ...
[JVM-1] [INFO] [10/29/2019 19:27:56.749] [ScalaTest-main] [akka.remote.Remoting] Remoting started; listening on addresses :[akka.tcp://MultiNodeOldestAutoDownSpec@localhost:54035]
[JVM-3] [INFO] [10/29/2019 19:27:56.765] [ScalaTest-main] [akka.cluster.Cluster(akka://MultiNodeOldestAutoDownSpec)] Cluster Node [akka.tcp://MultiNodeOldestAutoDownSpec@localhost:54033] - Started up successfully
[JVM-1] [INFO] [10/29/2019 19:27:56.777] [ScalaTest-main] [akka.cluster.Cluster(akka://MultiNodeOldestAutoDownSpec)] Cluster Node [akka.tcp://MultiNodeOldestAutoDownSpec@localhost:54035] - Starting up, Akka version [2.5.23] ...
[JVM-3] [INFO] [10/29/2019 19:27:56.814] [MultiNodeOldestAutoDownSpec-akka.actor.default-dispatcher-4] [akka.cluster.Cluster(akka://MultiNodeOldestAutoDownSpec)] Cluster Node [akka.tcp://MultiNodeOldestAutoDownSpec@localhost:54033] - No seed-nodes configured, manual cluster join required, see https://doc.akka.io/docs/akka/current/cluster-usage.html#joining-to-seed-nodes
[JVM-2] [INFO] [10/29/2019 19:27:56.821] [ScalaTest-main] [akka.cluster.Cluster(akka://MultiNodeOldestAutoDownSpec)] Cluster Node [akka.tcp://MultiNodeOldestAutoDownSpec@localhost:54034] - Started up successfully
[JVM-1] [INFO] [10/29/2019 19:27:56.849] [ScalaTest-main] [akka.cluster.Cluster(akka://MultiNodeOldestAutoDownSpec)] Cluster Node [akka.tcp://MultiNodeOldestAutoDownSpec@localhost:54035] - Started up successfully
[JVM-2] [INFO] [10/29/2019 19:27:56.860] [MultiNodeOldestAutoDownSpec-akka.actor.default-dispatcher-3] [akka.cluster.Cluster(akka://MultiNodeOldestAutoDownSpec)] Cluster Node [akka.tcp://MultiNodeOldestAutoDownSpec@localhost:54034] - No seed-nodes configured, manual cluster join required, see https://doc.akka.io/docs/akka/current/cluster-usage.html#joining-to-seed-nodes
[JVM-1] [INFO] [10/29/2019 19:27:56.896] [MultiNodeOldestAutoDownSpec-akka.actor.default-dispatcher-14] [akka.cluster.Cluster(akka://MultiNodeOldestAutoDownSpec)] Cluster Node [akka.tcp://MultiNodeOldestAutoDownSpec@localhost:54035] - No seed-nodes configured, manual cluster join required, see https://doc.akka.io/docs/akka/current/cluster-usage.html#joining-to-seed-nodes
[JVM-1] [INFO] [10/29/2019 19:27:58.004] [ScalaTest-main] [OldestAutoDowningNodeThatIsUnreachableWithAccrualFailureDetectorMultiJvmNode1(akka://MultiNodeOldestAutoDownSpec)] Role [master] started with address [akka.tcp://MultiNodeOldestAutoDownSpec@localhost:54035]
[JVM-2] [INFO] [10/29/2019 19:27:58.049] [ScalaTest-main] [OldestAutoDowningNodeThatIsUnreachableWithAccrualFailureDetectorMultiJvmNode2(akka://MultiNodeOldestAutoDownSpec)] Role [nodeB] started with address [akka.tcp://MultiNodeOldestAutoDownSpec@localhost:54034]
[JVM-3] [INFO] [10/29/2019 19:27:58.051] [ScalaTest-main] [OldestAutoDowningNodeThatIsUnreachableWithAccrualFailureDetectorMultiJvmNode3(akka://MultiNodeOldestAutoDownSpec)] Role [nodeC] started with address [akka.tcp://MultiNodeOldestAutoDownSpec@localhost:54033]
[JVM-1] Run starting. Expected test count is: 1
[JVM-1] OldestAutoDowningNodeThatIsUnreachableWithAccrualFailureDetectorMultiJvmNode1:
[JVM-1] Coroner Thread Count starts at 28 in tanukki.akka.cluster.autodown.issue22.OldestAutoDowningNodeThatIsUnreachableWithAccrualFailureDetectorMultiJvmNode1
[JVM-1] The oldest member in a 3 node cluster
[JVM-2] Run starting. Expected test count is: 1
[JVM-3] Run starting. Expected test count is: 1
[JVM-2] OldestAutoDowningNodeThatIsUnreachableWithAccrualFailureDetectorMultiJvmNode2:
[JVM-3] OldestAutoDowningNodeThatIsUnreachableWithAccrualFailureDetectorMultiJvmNode3:
[JVM-2] Coroner Thread Count starts at 25 in tanukki.akka.cluster.autodown.issue22.OldestAutoDowningNodeThatIsUnreachableWithAccrualFailureDetectorMultiJvmNode2
[JVM-3] Coroner Thread Count starts at 29 in tanukki.akka.cluster.autodown.issue22.OldestAutoDowningNodeThatIsUnreachableWithAccrualFailureDetectorMultiJvmNode3
[JVM-3] The oldest member in a 3 node cluster
[JVM-2] The oldest member in a 3 node cluster
[JVM-1] [INFO] [10/29/2019 19:27:58.162] [MultiNodeOldestAutoDownSpec-akka.actor.default-dispatcher-2] [akka.cluster.Cluster(akka://MultiNodeOldestAutoDownSpec)] Cluster Node [akka.tcp://MultiNodeOldestAutoDownSpec@localhost:54035] - Node [akka.tcp://MultiNodeOldestAutoDownSpec@localhost:54035] is JOINING itself (with roles [master, dc-default]) and forming new cluster
[JVM-1] [INFO] [10/29/2019 19:27:58.166] [MultiNodeOldestAutoDownSpec-akka.actor.default-dispatcher-2] [akka.cluster.Cluster(akka://MultiNodeOldestAutoDownSpec)] Cluster Node [akka.tcp://MultiNodeOldestAutoDownSpec@localhost:54035] - is the new leader among reachable nodes (more leaders may exist)
[JVM-1] [INFO] [10/29/2019 19:27:58.176] [MultiNodeOldestAutoDownSpec-akka.actor.default-dispatcher-2] [akka.cluster.Cluster(akka://MultiNodeOldestAutoDownSpec)] Cluster Node [akka.tcp://MultiNodeOldestAutoDownSpec@localhost:54035] - Leader is moving node [akka.tcp://MultiNodeOldestAutoDownSpec@localhost:54035] to [Up]
[JVM-1] [INFO] [10/29/2019 19:27:58.182] [MultiNodeOldestAutoDownSpec-akka.actor.default-dispatcher-3] [akka.tcp://MultiNodeOldestAutoDownSpec@localhost:54035/system/cluster/core/daemon/downingProvider] Member(address = akka.tcp://MultiNodeOldestAutoDownSpec@localhost:54035, status = Up) is up
[JVM-1] [INFO] [10/29/2019 19:27:58.426] [MultiNodeOldestAutoDownSpec-akka.actor.default-dispatcher-2] [akka.cluster.Cluster(akka://MultiNodeOldestAutoDownSpec)] Cluster Node [akka.tcp://MultiNodeOldestAutoDownSpec@localhost:54035] - Node [akka.tcp://MultiNodeOldestAutoDownSpec@localhost:54034] is JOINING, roles [role, dc-default]
[JVM-1] [INFO] [10/29/2019 19:27:58.427] [MultiNodeOldestAutoDownSpec-akka.actor.default-dispatcher-2] [akka.cluster.Cluster(akka://MultiNodeOldestAutoDownSpec)] Cluster Node [akka.tcp://MultiNodeOldestAutoDownSpec@localhost:54035] - Node [akka.tcp://MultiNodeOldestAutoDownSpec@localhost:54033] is JOINING, roles [role, dc-default]
[JVM-2] [INFO] [10/29/2019 19:27:58.492] [MultiNodeOldestAutoDownSpec-akka.actor.default-dispatcher-3] [akka.cluster.Cluster(akka://MultiNodeOldestAutoDownSpec)] Cluster Node [akka.tcp://MultiNodeOldestAutoDownSpec@localhost:54034] - Welcome from [akka.tcp://MultiNodeOldestAutoDownSpec@localhost:54035]
[JVM-3] [INFO] [10/29/2019 19:27:58.492] [MultiNodeOldestAutoDownSpec-akka.actor.default-dispatcher-15] [akka.cluster.Cluster(akka://MultiNodeOldestAutoDownSpec)] Cluster Node [akka.tcp://MultiNodeOldestAutoDownSpec@localhost:54033] - Welcome from [akka.tcp://MultiNodeOldestAutoDownSpec@localhost:54035]
[JVM-2] [INFO] [10/29/2019 19:27:58.508] [MultiNodeOldestAutoDownSpec-akka.actor.default-dispatcher-2] [akka.tcp://MultiNodeOldestAutoDownSpec@localhost:54034/system/cluster/core/daemon/downingProvider] Member(address = akka.tcp://MultiNodeOldestAutoDownSpec@localhost:54035, status = Up) is up
[JVM-3] [INFO] [10/29/2019 19:27:58.509] [MultiNodeOldestAutoDownSpec-akka.actor.default-dispatcher-2] [akka.tcp://MultiNodeOldestAutoDownSpec@localhost:54033/system/cluster/core/daemon/downingProvider] Member(address = akka.tcp://MultiNodeOldestAutoDownSpec@localhost:54035, status = Up) is up
[JVM-2] [INFO] [10/29/2019 19:27:58.544] [MultiNodeOldestAutoDownSpec-akka.actor.default-dispatcher-4] [akka.cluster.Cluster(akka://MultiNodeOldestAutoDownSpec)] Cluster Node [akka.tcp://MultiNodeOldestAutoDownSpec@localhost:54034] - Ignoring received gossip from unknown [UniqueAddress(akka.tcp://MultiNodeOldestAutoDownSpec@localhost:54033,5654232)]
[JVM-1] [INFO] [10/29/2019 19:27:58.590] [MultiNodeOldestAutoDownSpec-akka.actor.default-dispatcher-16] [akka.cluster.Cluster(akka://MultiNodeOldestAutoDownSpec)] Cluster Node [akka.tcp://MultiNodeOldestAutoDownSpec@localhost:54035] - Leader is moving node [akka.tcp://MultiNodeOldestAutoDownSpec@localhost:54033] to [Up]
[JVM-1] [INFO] [10/29/2019 19:27:58.590] [MultiNodeOldestAutoDownSpec-akka.actor.default-dispatcher-16] [akka.cluster.Cluster(akka://MultiNodeOldestAutoDownSpec)] Cluster Node [akka.tcp://MultiNodeOldestAutoDownSpec@localhost:54035] - Leader is moving node [akka.tcp://MultiNodeOldestAutoDownSpec@localhost:54034] to [Up]
[JVM-1] [INFO] [10/29/2019 19:27:58.590] [MultiNodeOldestAutoDownSpec-akka.actor.default-dispatcher-3] [akka.tcp://MultiNodeOldestAutoDownSpec@localhost:54035/system/cluster/core/daemon/downingProvider] Member(address = akka.tcp://MultiNodeOldestAutoDownSpec@localhost:54033, status = Up) is up
[JVM-1] [INFO] [10/29/2019 19:27:58.591] [MultiNodeOldestAutoDownSpec-akka.actor.default-dispatcher-3] [akka.tcp://MultiNodeOldestAutoDownSpec@localhost:54035/system/cluster/core/daemon/downingProvider] Member(address = akka.tcp://MultiNodeOldestAutoDownSpec@localhost:54034, status = Up) is up
[JVM-2] [INFO] [10/29/2019 19:27:58.765] [MultiNodeOldestAutoDownSpec-akka.actor.default-dispatcher-20] [akka.tcp://MultiNodeOldestAutoDownSpec@localhost:54034/system/cluster/core/daemon/downingProvider] Member(address = akka.tcp://MultiNodeOldestAutoDownSpec@localhost:54033, status = Up) is up
[JVM-2] [INFO] [10/29/2019 19:27:58.766] [MultiNodeOldestAutoDownSpec-akka.actor.default-dispatcher-21] [akka.tcp://MultiNodeOldestAutoDownSpec@localhost:54034/system/cluster/core/daemon/downingProvider] Member(address = akka.tcp://MultiNodeOldestAutoDownSpec@localhost:54034, status = Up) is up
[JVM-3] [INFO] [10/29/2019 19:27:58.792] [MultiNodeOldestAutoDownSpec-akka.actor.default-dispatcher-4] [akka.tcp://MultiNodeOldestAutoDownSpec@localhost:54033/system/cluster/core/daemon/downingProvider] Member(address = akka.tcp://MultiNodeOldestAutoDownSpec@localhost:54033, status = Up) is up
[JVM-3] [INFO] [10/29/2019 19:27:58.792] [MultiNodeOldestAutoDownSpec-akka.actor.default-dispatcher-4] [akka.tcp://MultiNodeOldestAutoDownSpec@localhost:54033/system/cluster/core/daemon/downingProvider] Member(address = akka.tcp://MultiNodeOldestAutoDownSpec@localhost:54034, status = Up) is up
[JVM-1] [INFO] [10/29/2019 19:27:58.797] [MultiNodeOldestAutoDownSpec-akka.actor.default-dispatcher-2] [akka.cluster.Cluster(akka://MultiNodeOldestAutoDownSpec)] Cluster Node [akka.tcp://MultiNodeOldestAutoDownSpec@localhost:54035] - is no longer leader
[JVM-3] [INFO] [10/29/2019 19:27:58.913] [MultiNodeOldestAutoDownSpec-akka.actor.default-dispatcher-15] [akka.cluster.Cluster(akka://MultiNodeOldestAutoDownSpec)] Cluster Node [akka.tcp://MultiNodeOldestAutoDownSpec@localhost:54033] - is the new leader among reachable nodes (more leaders may exist)
[JVM-3] [WARN] [10/29/2019 19:27:59.235] [New I/O worker #2] [NettyTransport(akka://MultiNodeOldestAutoDownSpec)] Remote connection to [localhost/127.0.0.1:54034] failed with java.io.IOException: Connection reset by peer
[JVM-1] [WARN] [10/29/2019 19:27:59.236] [New I/O worker #5] [NettyTransport(akka://MultiNodeOldestAutoDownSpec)] Remote connection to [/127.0.0.1:54041] failed with java.io.IOException: Connection reset by peer
[JVM-1] [WARN] [10/29/2019 19:27:59.280] [MultiNodeOldestAutoDownSpec-akka.remote.default-remote-dispatcher-4] [akka.tcp://MultiNodeOldestAutoDownSpec@localhost:54035/system/endpointManager/reliableEndpointWriter-akka.tcp%3A%2F%2FMultiNodeOldestAutoDownSpec%40localhost%3A54034-0] Association with remote system [akka.tcp://MultiNodeOldestAutoDownSpec@localhost:54034] has failed, address is now gated for [5000] ms. Reason: [Disassociated]
[JVM-1] [WARN] [10/29/2019 19:27:59.615] [New I/O worker #4] [NettyTransport(akka://MultiNodeOldestAutoDownSpec)] Remote connection to [/127.0.0.1:54040] failed with java.io.IOException: Connection reset by peer
[JVM-1] [WARN] [10/29/2019 19:27:59.616] [MultiNodeOldestAutoDownSpec-akka.remote.default-remote-dispatcher-17] [akka.tcp://MultiNodeOldestAutoDownSpec@localhost:54035/system/endpointManager/reliableEndpointWriter-akka.tcp%3A%2F%2FMultiNodeOldestAutoDownSpec%40localhost%3A54033-1] Association with remote system [akka.tcp://MultiNodeOldestAutoDownSpec@localhost:54033] has failed, address is now gated for [5000] ms. Reason: [Disassociated]
[JVM-1] [WARN] [10/29/2019 19:28:02.889] [MultiNodeOldestAutoDownSpec-akka.actor.default-dispatcher-2] [akka.cluster.Cluster(akka://MultiNodeOldestAutoDownSpec)] Cluster Node [akka.tcp://MultiNodeOldestAutoDownSpec@localhost:54035] - Marking node(s) as UNREACHABLE [Member(address = akka.tcp://MultiNodeOldestAutoDownSpec@localhost:54034, status = Up)]. Node roles [master, dc-default]
[JVM-1] [INFO] [10/29/2019 19:28:02.891] [MultiNodeOldestAutoDownSpec-akka.actor.default-dispatcher-16] [akka.tcp://MultiNodeOldestAutoDownSpec@localhost:54035/system/cluster/core/daemon/downingProvider] Member(address = akka.tcp://MultiNodeOldestAutoDownSpec@localhost:54034, status = Up) is unreachable
[JVM-1] [WARN] [10/29/2019 19:28:03.387] [MultiNodeOldestAutoDownSpec-akka.actor.default-dispatcher-14] [akka.cluster.Cluster(akka://MultiNodeOldestAutoDownSpec)] Cluster Node [akka.tcp://MultiNodeOldestAutoDownSpec@localhost:54035] - Marking node(s) as UNREACHABLE [Member(address = akka.tcp://MultiNodeOldestAutoDownSpec@localhost:54033, status = Up)]. Node roles [master, dc-default]
[JVM-1] [INFO] [10/29/2019 19:28:03.387] [MultiNodeOldestAutoDownSpec-akka.actor.default-dispatcher-14] [akka.tcp://MultiNodeOldestAutoDownSpec@localhost:54035/system/cluster/core/daemon/downingProvider] Member(address = akka.tcp://MultiNodeOldestAutoDownSpec@localhost:54033, status = Up) is unreachable
[JVM-1] [INFO] [10/29/2019 19:28:03.397] [MultiNodeOldestAutoDownSpec-akka.actor.default-dispatcher-14] [akka.cluster.Cluster(akka://MultiNodeOldestAutoDownSpec)] Cluster Node [akka.tcp://MultiNodeOldestAutoDownSpec@localhost:54035] - is the new leader among reachable nodes (more leaders may exist)
[JVM-1] [INFO] [10/29/2019 19:28:04.407] [MultiNodeOldestAutoDownSpec-akka.actor.default-dispatcher-15] [akka.tcp://MultiNodeOldestAutoDownSpec@localhost:54035/system/cluster/core/daemon/downingProvider] Oldest is auto-downing unreachable node [akka.tcp://MultiNodeOldestAutoDownSpec@localhost:54034]
[JVM-1] [INFO] [10/29/2019 19:28:04.408] [MultiNodeOldestAutoDownSpec-akka.actor.default-dispatcher-2] [akka.cluster.Cluster(akka://MultiNodeOldestAutoDownSpec)] Cluster Node [akka.tcp://MultiNodeOldestAutoDownSpec@localhost:54035] - Marking unreachable node [akka.tcp://MultiNodeOldestAutoDownSpec@localhost:54034] as [Down]
[JVM-1] [INFO] [10/29/2019 19:28:04.409] [MultiNodeOldestAutoDownSpec-akka.actor.default-dispatcher-3] [akka.tcp://MultiNodeOldestAutoDownSpec@localhost:54035/system/cluster/core/daemon/downingProvider] Member(address = akka.tcp://MultiNodeOldestAutoDownSpec@localhost:54034, status = Down) was downed
[JVM-1] [INFO] [10/29/2019 19:28:04.412] [MultiNodeOldestAutoDownSpec-akka.actor.default-dispatcher-3] [akka.tcp://MultiNodeOldestAutoDownSpec@localhost:54035/system/cluster/core/daemon/downingProvider] Oldest is auto-downing unreachable node [akka.tcp://MultiNodeOldestAutoDownSpec@localhost:54033]
[JVM-1] [INFO] [10/29/2019 19:28:04.412] [MultiNodeOldestAutoDownSpec-akka.actor.default-dispatcher-15] [akka.cluster.Cluster(akka://MultiNodeOldestAutoDownSpec)] Cluster Node [akka.tcp://MultiNodeOldestAutoDownSpec@localhost:54035] - Marking unreachable node [akka.tcp://MultiNodeOldestAutoDownSpec@localhost:54033] as [Down]
[JVM-1] [INFO] [10/29/2019 19:28:04.413] [MultiNodeOldestAutoDownSpec-akka.actor.default-dispatcher-2] [akka.tcp://MultiNodeOldestAutoDownSpec@localhost:54035/system/cluster/core/daemon/downingProvider] Member(address = akka.tcp://MultiNodeOldestAutoDownSpec@localhost:54033, status = Down) was downed
[JVM-1] [INFO] [10/29/2019 19:28:04.599] [MultiNodeOldestAutoDownSpec-akka.actor.default-dispatcher-14] [akka.cluster.Cluster(akka://MultiNodeOldestAutoDownSpec)] Cluster Node [akka.tcp://MultiNodeOldestAutoDownSpec@localhost:54035] - Leader is removing unreachable node [akka.tcp://MultiNodeOldestAutoDownSpec@localhost:54034]
[JVM-1] [INFO] [10/29/2019 19:28:04.599] [MultiNodeOldestAutoDownSpec-akka.actor.default-dispatcher-14] [akka.cluster.Cluster(akka://MultiNodeOldestAutoDownSpec)] Cluster Node [akka.tcp://MultiNodeOldestAutoDownSpec@localhost:54035] - Leader is removing unreachable node [akka.tcp://MultiNodeOldestAutoDownSpec@localhost:54033]
[JVM-1] [INFO] [10/29/2019 19:28:04.600] [MultiNodeOldestAutoDownSpec-akka.actor.default-dispatcher-15] [akka.tcp://MultiNodeOldestAutoDownSpec@localhost:54035/system/cluster/core/daemon/downingProvider] Member(address = akka.tcp://MultiNodeOldestAutoDownSpec@localhost:54033, status = Removed) was removed from the cluster
[JVM-1] [INFO] [10/29/2019 19:28:04.601] [MultiNodeOldestAutoDownSpec-akka.actor.default-dispatcher-15] [akka.tcp://MultiNodeOldestAutoDownSpec@localhost:54035/system/cluster/core/daemon/downingProvider] Member(address = akka.tcp://MultiNodeOldestAutoDownSpec@localhost:54034, status = Removed) was removed from the cluster
[JVM-1] - must issue-22
[JVM-1] Coroner Thread Count started at 28, ended at 14, peaked at 34 in tanukki.akka.cluster.autodown.issue22.OldestAutoDowningNodeThatIsUnreachableWithAccrualFailureDetectorMultiJvmNode1
[JVM-1] Run completed in 9 seconds, 21 milliseconds.
[JVM-1] Total number of tests run: 1
[JVM-1] Suites: completed 1, aborted 0
[JVM-1] Tests: succeeded 1, failed 0, canceled 0, ignored 0, pending 0
[JVM-1] All tests passed.
[info] tanukki.akka.cluster.autodown.issue22.OldestAutoDowningNodeThatIsUnreachableWithAccrualFailureDetector
[info] No tests to run for MultiJvm
[success] Total time: 15 s, completed 2019/10/29 19:28:04
```